### PR TITLE
Daplink Information from CMSIS Packs

### DIFF
--- a/scripts/c_blob.tmpl
+++ b/scripts/c_blob.tmpl
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+ #include "flash_blob.h"
 
-static const uint32_t {{name}}_flash_prog_blob[] = {
+static const uint32_t _flash_prog_blob[] = {
     {{prog_header}}
     {{algo.format_algo_data(4, 8, "c")}}
 };
@@ -55,7 +56,8 @@ static const program_target_t flash = {
 
     {{'0x%08x' % entry}} + 0x00000A00,  // mem buffer location
     {{'0x%08x' % entry}},               // location to write prog_blob in target RAM
-    sizeof({{name}}_flash_prog_blob),   // prog_blob size
-    {{name}}_flash_prog_blob,           // address of prog_blob
+    sizeof(_flash_prog_blob),   // prog_blob size
+    _flash_prog_blob,           // address of prog_blob
     {{'0x%08x' % algo.page_size}}       // ram_to_flash_bytes_to_be_written
 };
+

--- a/scripts/c_blob.tmpl
+++ b/scripts/c_blob.tmpl
@@ -32,9 +32,9 @@ static const uint32_t flash_size = {{"0x%08x" % algo.flash_size}};
 * The last pair in the list will have sectors starting at that address and ending
 * at address flash_start + flash_size.
 */
-static const uint32_t sectors_info[] = {
+static const sector_info_t sectors_info[] = {
 {%- for start, size  in algo.sector_sizes %}
-    {{ "0x%08x, 0x%08x" % (start + algo.flash_start, size) }},
+    {{ "{0x%08x, 0x%08x}" % (start + algo.flash_start, size) }},
 {%- endfor %}
 };
 

--- a/scripts/c_blob.tmpl
+++ b/scripts/c_blob.tmpl
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+ // Device: {{name}}
+ 
  #include "flash_blob.h"
 
 static const uint32_t _flash_prog_blob[] = {

--- a/scripts/c_blob.tmpl
+++ b/scripts/c_blob.tmpl
@@ -22,11 +22,6 @@ static const uint32_t _flash_prog_blob[] = {
     {{algo.format_algo_data(4, 8, "c")}}
 };
 
-// Start address of flash
-static const uint32_t flash_start = {{"0x%08x" % algo.flash_start}};
-// Size of flash
-static const uint32_t flash_size = {{"0x%08x" % algo.flash_size}};
-
 /**
 * List of start and size for each size of flash sector - even indexes are start, odd are size
 * The size will apply to all sectors between the listed address and the next address

--- a/scripts/c_blob_mbed.tmpl
+++ b/scripts/c_blob_mbed.tmpl
@@ -38,7 +38,7 @@ static const flash_algo_t flash_algo_config = {
 
 static const sector_info_t sectors_info[] = {
 {%- for start, size  in algo.sector_sizes %}
-    {{ "{0x%x, 0x%x}" % (start + algo.flash_start, size) }}, 
+    {{ "{0x%x, 0x%x}" % (start + algo.flash_start, size) }},
 {%- endfor %}
 };
 

--- a/scripts/c_target.tmpl
+++ b/scripts/c_target.tmpl
@@ -34,6 +34,6 @@ target_cfg_t target_device = {
     .ram_end            = {{'0x%08x' % (ram_start + ram_size)}},
     .flash_algo         = (program_target_t *) &flash,
     .sectors_info       = sectors_info,
-    .sector_info_length = (sizeof(sectors_info))/(sizeof(sectors_info_t))
+    .sector_info_length = (sizeof(sectors_info))/(sizeof(sector_info_t))
 };
 

--- a/scripts/c_target.tmpl
+++ b/scripts/c_target.tmpl
@@ -26,12 +26,14 @@
 
 // target information
 target_cfg_t target_device = {
-    .sector_size    = {{'0x%x' % sector_size}},
-    .sector_cnt     = ({{'0x%x' % flash_size}} / {{'0x%x' % sector_size}}),
-    .flash_start    = {{'0x%08x' % flash_start}},
-    .flash_end      = {{'0x%08x' % (flash_start + flash_size)}},
-    .ram_start      = {{'0x%08x' % ram_start}},
-    .ram_end        = {{'0x%08x' % (ram_start + ram_size)}},
-    .flash_algo     = (program_target_t *) &flash,
+    .sector_size        = {{'0x%x' % sector_size}},
+    .sector_cnt         = ({{'0x%x' % flash_size}} / {{'0x%x' % sector_size}}),
+    .flash_start        = {{'0x%08x' % flash_start}},
+    .flash_end          = {{'0x%08x' % (flash_start + flash_size)}},
+    .ram_start          = {{'0x%08x' % ram_start}},
+    .ram_end            = {{'0x%08x' % (ram_start + ram_size)}},
+    .flash_algo         = (program_target_t *) &flash,
+    .sectors_info       = sectors_info,
+    .sector_info_length = (sizeof(sectors_info))/(sizeof(sectors_info[0]))
 };
 

--- a/scripts/c_target.tmpl
+++ b/scripts/c_target.tmpl
@@ -26,8 +26,6 @@
 
 // target information
 target_cfg_t target_device = {
-    .sector_size        = {{'0x%x' % sector_size}},
-    .sector_cnt         = ({{'0x%x' % flash_size}} / {{'0x%x' % sector_size}}),
     .flash_start        = {{'0x%08x' % flash_start}},
     .flash_end          = {{'0x%08x' % (flash_start + flash_size)}},
     .ram_start          = {{'0x%08x' % ram_start}},

--- a/scripts/c_target.tmpl
+++ b/scripts/c_target.tmpl
@@ -34,6 +34,6 @@ target_cfg_t target_device = {
     .ram_end            = {{'0x%08x' % (ram_start + ram_size)}},
     .flash_algo         = (program_target_t *) &flash,
     .sectors_info       = sectors_info,
-    .sector_info_length = (sizeof(sectors_info))/(sizeof(sectors_info[0]))
+    .sector_info_length = (sizeof(sectors_info))/(sizeof(sectors_info_t))
 };
 

--- a/scripts/c_target.tmpl
+++ b/scripts/c_target.tmpl
@@ -1,0 +1,37 @@
+/**
+ * @file    target.c
+ * @brief   Target information for the {{name}}
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2017-2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "target_config.h"
+
+// The file flash_blob.c must only be included in target.c
+#include "flash_blob.c"
+
+// target information
+target_cfg_t target_device = {
+    .sector_size    = {{'0x%x' % sector_size}},
+    .sector_cnt     = ({{'0x%x' % flash_size}} / {{'0x%x' % sector_size}}),
+    .flash_start    = {{'0x%08x' % flash_start}},
+    .flash_end      = {{'0x%08x' % (flash_start + flash_size)}},
+    .ram_start      = {{'0x%08x' % ram_start}},
+    .ram_end        = {{'0x%08x' % (ram_start + ram_size)}},
+    .flash_algo     = (program_target_t *) &flash,
+};
+

--- a/scripts/generate_blobs_from_pack.py
+++ b/scripts/generate_blobs_from_pack.py
@@ -28,6 +28,7 @@ from flash_algo import PackFlashAlgo
 from cmsis_pack_manager import Cache
 from jinja2 import Template
 from fuzzywuzzy import process
+import json
 
 # TODO
 # FIXED LENGTH - remove and these (shrink offset to 4 for bkpt only)
@@ -41,6 +42,8 @@ tmpl_name_list = [
     ("py_blob.tmpl", "py_blob", "py"),
     ("c_blob_mbed.tmpl", "c_blob_mbed", "c")
 ]
+
+name_map = {}
 
 def main():
     parser = argparse.ArgumentParser(description="Blob generator")
@@ -76,6 +79,9 @@ def main():
             print ("%d/%d"%(count,total_targets))
             count += 1
             output_files(cache, target, output_path, args.blob_start, args.all)
+        name_map_path = join(args.daplink, "daplink_to_cmsis.json")
+        with open(name_map_path, 'w') as f:
+            json.dump(name_map, f, indent=4)
 
 def find_possible(match, choices):
     return process.extractOne(match, choices)
@@ -116,6 +122,7 @@ def write_target_c_file(dev, algo, output_path, target):
 
 def output_files(cache, target, output_dir, blob_start, all_algo):
     dev, device = find_match(cache, target)
+    name_map[target] = device if dev else "No Match"
     if (dev is None):
         print "No match for %s"%(target)
         return

--- a/scripts/generate_blobs_from_pack.py
+++ b/scripts/generate_blobs_from_pack.py
@@ -18,27 +18,32 @@ limitations under the License.
 This script takes the path to file(s) created by an image conversion tool
 (fromelf or arm-elf-objcopy) as input. These files (bin and text) are used
 to create flash programming blobs (instruction arrays) which are then
-loaded into the target MCU RAM. Generates files compatible with C programs 
+loaded into the target MCU RAM. Generates files compatible with C programs
 and python programs (DAPLink Interface Firmware and pyDAPFlash)
 '''
 import os
 import argparse
 from os.path import join
 from flash_algo import PackFlashAlgo
-from ArmPackManager import Cache
+from cmsis_pack_manager import Cache
 from jinja2 import Template
+from fuzzywuzzy import process
 
 # TODO
 # FIXED LENGTH - remove and these (shrink offset to 4 for bkpt only)
 BLOB_HEADER = '0xE00ABE00, 0x062D780D, 0x24084068, 0xD3000040, 0x1E644058, 0x1C49D1FA, 0x2A001E52, 0x4770D1F2,'
 HEADER_SIZE = 0x20
 
-OUTPUT_DIR = "output"
+template_dir = os.path.dirname(os.path.realpath(__file__))
 
+tmpl_name_list = [
+    ("c_blob.tmpl", "c_blob", "c"),
+    ("py_blob.tmpl", "py_blob", "py"),
+    ("c_blob_mbed.tmpl", "c_blob_mbed", "c")
+]
 
 def main():
     parser = argparse.ArgumentParser(description="Blob generator")
-    parser.add_argument("device", help="Device name to generate algo for")
     parser.add_argument("--rebuild_all", action="store_true",
                         help="Rebuild entire cache")
     parser.add_argument("--rebuild_descriptors", action="store_true",
@@ -46,10 +51,11 @@ def main():
     parser.add_argument("--blob_start", type=lambda x: int(x, 0), default=None,
                         help="Starting address of the flash blob."
                         "Used only for DAPLink.")
+    parser.add_argument("--daplink", default=None,
+                        help="Root location of daplink")
     parser.add_argument("--all", action="store_true",
                         help="Build all flash algos for devcies")
     args = parser.parse_args()
-    device = args.device
 
     cache = Cache(True, True)
     if args.rebuild_all:
@@ -62,67 +68,87 @@ def main():
         print("Descriptors rebuilt")
         exit(0)
 
-    dev = cache.index[device]
-    algo_ram = (get_algo_ram(dev, (None, None))[0] if args.blob_start is None
-                else args.blob_start)
+    if args.daplink:
+        target_to_dir = get_daplink_files(args.daplink)
+        total_targets = len(target_to_dir.keys())
+        count = 1
+        for target, output_path in target_to_dir.items():
+            print ("%d/%d"%(count,total_targets))
+            count += 1
+            output_files(cache, target, output_path, args.blob_start, args.all)
+
+def find_possible(match, choices):
+    return process.extractOne(match, choices)
+
+def find_match(cache, daplink_target_name):
+    fuzz1 = find_possible(daplink_target_name, cache.aliases.keys())
+    fuzz2 = find_possible(daplink_target_name, cache.index.keys())
+    if fuzz1[1] >= 90:
+        device = cache.aliases[fuzz1[0]]
+        if device not in cache.index and fuzz2[1] >= 90:
+            device = fuzz2[0]
+    elif fuzz2[1] >= 90:
+        device = fuzz2[0]
+    else:
+        return None, None
+    return cache.index[device], device
+
+def write_target_c_file(dev, algo, output_path, target):
+    tmpl = "c_target.tmpl"
+    template_path = os.path.join(template_dir, tmpl)
+    ram_start, ram_size = get_algo_ram(dev)
+    rom_start, rom_size = get_algo_rom(dev)
+    target_data_dict = {
+        'name': target,
+        "flash_start": rom_start,
+        "flash_size": rom_size,
+        "sector_size": algo.sector_sizes[0][1],
+        "ram_start": ram_start,
+        "ram_size": ram_size,
+    }
+    with open(template_path) as file_handle:
+        template_text = file_handle.read()
+    template = Template(template_text)
+    target_text = template.render(target_data_dict)
+    with open(output_path, "wb") as file_handle:
+        file_handle.write(target_text)
+
+
+def output_files(cache, target, output_dir, blob_start, all_algo):
+    dev, device = find_match(cache, target)
+    if (dev is None):
+        print "No match for %s"%(target)
+        return
+    algo_ram = (get_algo_ram(dev, (None, None))[0] if blob_start is None
+                else blob_start)
     if algo_ram is None:
-        print("Ram address must be specified with --blob_start")
-        exit(-1)
+        print("No ram address for %s"%target)
+        return
 
-    try:
-        os.mkdir(OUTPUT_DIR)
-    except OSError:
-        # Directory already exists
-        pass
-
-    basename = device.replace("/", "_")
-    template_dir = os.path.dirname(os.path.realpath(__file__))
-    output_dir = OUTPUT_DIR
+    print "%s/%s writing to %s"%(target,device,output_dir)
     SP = algo_ram + 2048
     data_dict = {
-        'name': basename,
+        'name': target,
         'prog_header': BLOB_HEADER,
         'header_size': HEADER_SIZE,
         'entry': algo_ram,
         'stack_pointer': SP,
     }
 
-    tmpl_name_list = [
-        ("c_blob.tmpl", "c_blob", "c"),
-        ("py_blob.tmpl", "py_blob", "py"),
-        ("c_blob_mbed.tmpl", "c_blob_mbed", "c")
-    ]
-
     binaries = cache.get_flash_algorthim_binary(device, all=True)
     algos = [PackFlashAlgo(binary.read()) for binary in binaries]
-    filtered_algos = algos if args.all else filter_algos(dev, algos)
+    filtered_algos = algos if all_algo else filter_algos(dev, algos)
     for idx, algo in enumerate(filtered_algos):
-        index_str = ("_%i" % idx if args.all or
+        index_str = ("_%i" % idx if all_algo or
                      len(filtered_algos) != 1 else "")
-        for tmpl, filebase, ext in tmpl_name_list:
-            filename = basename + index_str + "_" + filebase + "." + ext
-            template_path = os.path.join(template_dir, tmpl)
-            output_path = os.path.join(output_dir, filename)
-            algo.process_template(template_path, output_path, data_dict)
 
-        filename = basename + index_str + "_target.c"
-        output_path = os.path.join(output_dir, filename)
-        TARGET_TEMPLATE = "c_target.tmpl"
-        ram_start, ram_size = get_algo_ram(dev)
-        rom_start, rom_size = get_algo_rom(dev)
-        target_data_dict = {
-            "flash_start": rom_start,
-            "flash_size": rom_size,
-            "sector_size": algo.sector_sizes[0][1],
-            "ram_start": ram_start,
-            "ram_size": ram_size,
-        }
-        with open(TARGET_TEMPLATE) as file_handle:
-            template_text = file_handle.read()
-        template = Template(template_text)
-        target_text = template.render(target_data_dict)
-        with open(output_path, "wb") as file_handle:
-            file_handle.write(target_text)
+        tmpl = "c_blob.tmpl"
+        template_path = os.path.join(template_dir, tmpl)
+        output_path = os.path.join(output_dir, "flash_blob.c")
+        algo.process_template(template_path, output_path, data_dict)
+
+        output_path = os.path.join(output_dir, "target.c")
+        write_target_c_file(dev, algo, output_path, target)
 
         warnings = get_algo_warnings(algo)
         if warnings is not None:
@@ -137,6 +163,17 @@ def main():
         print("Device %s warnings" % device)
         for warning in warnings:
             print("  -%s" % warning)
+
+
+def get_daplink_files(daplink_root):
+    daplink_targets = join(daplink_root, 'source', 'target')
+    target_to_dir = {}
+    print(os.getcwd())
+    for root,dirs,files in os.walk(daplink_targets):
+        if 'flash_blob.c' in files:
+            target = os.path.basename(os.path.normpath(root))
+            target_to_dir[target] = root
+    return target_to_dir
 
 
 def get_algo_warnings(algo):
@@ -177,16 +214,40 @@ def get_dev_warnings(dev):
 def get_algo_rom(dev, errval=(0xDEADBEEF, 0xDEADBEEF)):
     if "memory" not in dev:
         return errval
-    if "IROM1" not in dev["memory"]:
+    if "IROM1" in dev["memory"]:
+        rom_rgn = dev["memory"]["IROM1"]
+    elif "PROGRAM_FLASH" in dev["memory"]:
+        rom_rgn = dev["memory"]["PROGRAM_FLASH"]
+    else:
         return errval
 
-    rom_rgn = dev["memory"]["IROM1"]
     try:
         start = int(rom_rgn["start"], 0)
         size = int(rom_rgn["size"], 0)
     except ValueError:
         return errval
     return start, size
+
+def merge_ram(rgn1, rgn2):
+    ret_rgn = {}
+    if(int(rgn1["start"],0) < int(rgn2["start"],0)):
+        lower_rgn = rgn1
+        upper_rgn = rgn2
+    else:
+        lower_rgn = rgn2
+        upper_rgn = rgn1
+
+    rgn1_start = int(lower_rgn["start"],0)
+    rgn2_start = int(upper_rgn["start"],0)
+    rgn1_size  = int(lower_rgn["size"],0)
+    rgn2_size  = int(upper_rgn["size"],0)
+
+    if((rgn1_start + rgn1_size) == rgn2_start):
+        ret_rgn["start"] = hex(rgn1_start)
+        ret_rgn["size"] = hex(rgn1_size + rgn2_size)
+        return ret_rgn
+    else:
+        return rgn1
 
 
 def get_algo_ram(dev, errval=(0xDEADBEEF, 0xDEADBEEF)):
@@ -196,6 +257,9 @@ def get_algo_ram(dev, errval=(0xDEADBEEF, 0xDEADBEEF)):
         return errval
 
     ram_rgn = dev["memory"]["IRAM1"]
+    if "IRAM2" in dev["memory"]:
+        ram_rgn2 = dev["memory"]["IRAM2"]
+        ram_rgn = merge_ram(ram_rgn, ram_rgn2)
     try:
         start = int(ram_rgn["start"], 0)
         size = int(ram_rgn["size"], 0)
@@ -207,12 +271,16 @@ def get_algo_ram(dev, errval=(0xDEADBEEF, 0xDEADBEEF)):
 def filter_algos(dev, algos):
     if "memory" not in dev:
         return algos
-    if "IROM1" not in dev["memory"]:
-        return algos
     if "IROM2" in dev["memory"]:
         return algos
 
-    rom_rgn = dev["memory"]["IROM1"]
+    if "IROM1" in dev["memory"]:
+        rom_rgn = dev["memory"]["IROM1"]
+    elif "PROGRAM_FLASH" in dev["memory"]:
+        rom_rgn = dev["memory"]["PROGRAM_FLASH"]
+    else:
+        return algos
+
     try:
         start = int(rom_rgn["start"], 0)
         size = int(rom_rgn["size"], 0)

--- a/scripts/generate_blobs_from_pack.py
+++ b/scripts/generate_blobs_from_pack.py
@@ -1,0 +1,228 @@
+'''
+FlashAlgo
+Copyright (c) 2011-2017 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+This script takes the path to file(s) created by an image conversion tool
+(fromelf or arm-elf-objcopy) as input. These files (bin and text) are used
+to create flash programming blobs (instruction arrays) which are then
+loaded into the target MCU RAM. Generates files compatible with C programs 
+and python programs (DAPLink Interface Firmware and pyDAPFlash)
+'''
+import os
+import argparse
+from os.path import join
+from flash_algo import PackFlashAlgo
+from ArmPackManager import Cache
+from jinja2 import Template
+
+# TODO
+# FIXED LENGTH - remove and these (shrink offset to 4 for bkpt only)
+BLOB_HEADER = '0xE00ABE00, 0x062D780D, 0x24084068, 0xD3000040, 0x1E644058, 0x1C49D1FA, 0x2A001E52, 0x4770D1F2,'
+HEADER_SIZE = 0x20
+
+OUTPUT_DIR = "output"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Blob generator")
+    parser.add_argument("device", help="Device name to generate algo for")
+    parser.add_argument("--rebuild_all", action="store_true",
+                        help="Rebuild entire cache")
+    parser.add_argument("--rebuild_descriptors", action="store_true",
+                        help="Rebuild descriptors")
+    parser.add_argument("--blob_start", type=lambda x: int(x, 0), default=None,
+                        help="Starting address of the flash blob."
+                        "Used only for DAPLink.")
+    parser.add_argument("--all", action="store_true",
+                        help="Build all flash algos for devcies")
+    args = parser.parse_args()
+    device = args.device
+
+    cache = Cache(True, True)
+    if args.rebuild_all:
+        cache.cache_everything()
+        print("Cache rebuilt")
+        exit(0)
+
+    if args.rebuild_descriptors:
+        cache.cache_descriptors()
+        print("Descriptors rebuilt")
+        exit(0)
+
+    dev = cache.index[device]
+    algo_ram = (get_algo_ram(dev, (None, None))[0] if args.blob_start is None
+                else args.blob_start)
+    if algo_ram is None:
+        print("Ram address must be specified with --blob_start")
+        exit(-1)
+
+    try:
+        os.mkdir(OUTPUT_DIR)
+    except OSError:
+        # Directory already exists
+        pass
+
+    basename = device.replace("/", "_")
+    template_dir = os.path.dirname(os.path.realpath(__file__))
+    output_dir = OUTPUT_DIR
+    SP = algo_ram + 2048
+    data_dict = {
+        'name': basename,
+        'prog_header': BLOB_HEADER,
+        'header_size': HEADER_SIZE,
+        'entry': algo_ram,
+        'stack_pointer': SP,
+    }
+
+    tmpl_name_list = [
+        ("c_blob.tmpl", "c_blob", "c"),
+        ("py_blob.tmpl", "py_blob", "py"),
+        ("c_blob_mbed.tmpl", "c_blob_mbed", "c")
+    ]
+
+    binaries = cache.get_flash_algorthim_binary(device, all=True)
+    algos = [PackFlashAlgo(binary.read()) for binary in binaries]
+    filtered_algos = algos if args.all else filter_algos(dev, algos)
+    for idx, algo in enumerate(filtered_algos):
+        index_str = ("_%i" % idx if args.all or
+                     len(filtered_algos) != 1 else "")
+        for tmpl, filebase, ext in tmpl_name_list:
+            filename = basename + index_str + "_" + filebase + "." + ext
+            template_path = os.path.join(template_dir, tmpl)
+            output_path = os.path.join(output_dir, filename)
+            algo.process_template(template_path, output_path, data_dict)
+
+        filename = basename + index_str + "_target.c"
+        output_path = os.path.join(output_dir, filename)
+        TARGET_TEMPLATE = "c_target.tmpl"
+        ram_start, ram_size = get_algo_ram(dev)
+        rom_start, rom_size = get_algo_rom(dev)
+        target_data_dict = {
+            "flash_start": rom_start,
+            "flash_size": rom_size,
+            "sector_size": algo.sector_sizes[0][1],
+            "ram_start": ram_start,
+            "ram_size": ram_size,
+        }
+        with open(TARGET_TEMPLATE) as file_handle:
+            template_text = file_handle.read()
+        template = Template(template_text)
+        target_text = template.render(target_data_dict)
+        with open(output_path, "wb") as file_handle:
+            file_handle.write(target_text)
+
+        warnings = get_algo_warnings(algo)
+        if warnings is not None:
+            print("Device %s algo %s warnings:" % (device, idx))
+            for warning in warnings:
+                print("  -%s" % warning)
+
+    warnings = get_dev_warnings(dev)
+    if warnings is None:
+        print("No Device warnings")
+    else:
+        print("Device %s warnings" % device)
+        for warning in warnings:
+            print("  -%s" % warning)
+
+
+def get_algo_warnings(algo):
+    warnings = []
+    if len(algo.sector_sizes) != 1:
+        warnings.append("Device contains varaiable sized sectors (%s)" %
+                        len(algo.sector_sizes))
+    if algo.symbols['EraseChip'] == 0xffffffff:
+        warnings.append("Device does not support chip erase")
+    return None if len(warnings) == 0 else warnings
+
+
+def get_dev_warnings(dev):
+    warnings = []
+    if "memory" not in dev:
+        return ["No memory region defined for device"]
+
+    memory = dev["memory"]
+    for region in ("IROM1", "IRAM1"):
+        if region in dev["memory"]:
+            try:
+                int(memory[region]["start"], 0)
+                int(memory[region]["size"], 0)
+            except ValueError:
+                warnings.append("Region %s attributes invalid" % region)
+            except KeyError:
+                warnings.append("Region %s attributes missing" % region)
+        else:
+            warnings.append("Device does not contain required region %s" %
+                            region)
+
+    for name, region in dev["memory"].items():
+        if name not in ("IROM1", "IRAM1"):
+            warnings.append("Unknown region %s" % name)
+    return None if len(warnings) == 0 else warnings
+
+
+def get_algo_rom(dev, errval=(0xDEADBEEF, 0xDEADBEEF)):
+    if "memory" not in dev:
+        return errval
+    if "IROM1" not in dev["memory"]:
+        return errval
+
+    rom_rgn = dev["memory"]["IROM1"]
+    try:
+        start = int(rom_rgn["start"], 0)
+        size = int(rom_rgn["size"], 0)
+    except ValueError:
+        return errval
+    return start, size
+
+
+def get_algo_ram(dev, errval=(0xDEADBEEF, 0xDEADBEEF)):
+    if "memory" not in dev:
+        return errval
+    if "IRAM1" not in dev["memory"]:
+        return errval
+
+    ram_rgn = dev["memory"]["IRAM1"]
+    try:
+        start = int(ram_rgn["start"], 0)
+        size = int(ram_rgn["size"], 0)
+    except ValueError:
+        return errval
+    return start, size
+
+
+def filter_algos(dev, algos):
+    if "memory" not in dev:
+        return algos
+    if "IROM1" not in dev["memory"]:
+        return algos
+    if "IROM2" in dev["memory"]:
+        return algos
+
+    rom_rgn = dev["memory"]["IROM1"]
+    try:
+        start = int(rom_rgn["start"], 0)
+        size = int(rom_rgn["size"], 0)
+    except ValueError:
+        return algos
+
+    matching_algos = [algo for algo in algos if
+                      algo.flash_start == start and algo.flash_size == size]
+    return matching_algos if len(matching_algos) == 1 else algos
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Generate DapLink Flash blobs from CMSIS packs.

To run the command:
`python generate_blobs_from_pack.py --daplink path/to/DapLink`

This will use cmsis-pack-manager to find FLM files to parse for DapLink c blob file information.

It will take in the root location of a DapLink clone and place target files in the appropriate place. It will also generate a file `daplink_to_cmsis.json`, which will map the CMSIS part name to DapLink target name. See an example here - https://github.com/sarahmarshy/DAPLink/blob/0af00555ae33b40a2d40430077d22bf284feecda/daplink_to_cmsis.json

To explicitly specify DapLink target to CMSIS part name, create a file called `board_to_pack.json` and place it in the same location as the script will be executed. An example of this file is as follows:
```
{
     "k28f": "MK28FN2M0xxx15",
     "kl26z": "MKL26Z128xxx4"
}
```



@c1728p9 