### PR TITLE
fix linux build: use consistent case when including header files

### DIFF
--- a/source/arm/gfc100/FlashDev.c
+++ b/source/arm/gfc100/FlashDev.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!
 

--- a/source/arm/gfc100/FlashPrg.c
+++ b/source/arm/gfc100/FlashPrg.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 #include "gfc100_eflash_drv.h"
 
 #define  SYSTEM_CLOCK    (40960000UL)

--- a/source/arm/mt25ql512/FlashDev.c
+++ b/source/arm/mt25ql512/FlashDev.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!
 

--- a/source/arm/mt25ql512/FlashPrg.c
+++ b/source/arm/mt25ql512/FlashPrg.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 #include "mt25ql_flash_lib.h"
 
 static const struct qspi_ip6514e_dev_cfg_t QSPI_DEV_CFG = {

--- a/source/freescale/FlashDev.c
+++ b/source/freescale/FlashDev.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!
 #define DEVICE_NAME    "MKXX"

--- a/source/freescale/FlashPrg.c
+++ b/source/freescale/FlashPrg.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 #include "fsl_flash.h"
 #include "string.h"
 

--- a/source/nordic/FlashDev.c
+++ b/source/nordic/FlashDev.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"
+#include "FlashOS.h"
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!
 #define DEVICE_NAME    "nRF51822AA 256 KB Flash"

--- a/source/nordic/FlashPrg.c
+++ b/source/nordic/FlashPrg.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"
+#include "FlashOS.h"
 
 #define U8  unsigned char
 #define U16 unsigned short

--- a/source/nxp/iap/FlashDev.c
+++ b/source/nxp/iap/FlashDev.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "../FlashOS.H"        // FlashOS Structures
+#include "../FlashOS.h"        // FlashOS Structures
 
 #ifdef MBED
 #ifdef LPC1700_512

--- a/source/nxp/iap/FlashPrg.c
+++ b/source/nxp/iap/FlashPrg.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "../FlashOS.H"        // FlashOS Structures
+#include "../FlashOS.h"        // FlashOS Structures
 
 // Memory Mapping Control
 #if defined(LPC11xx_32) || defined(LPC8xx_4) || defined(LPC11U68_256)

--- a/source/nxp/iap_32kb/FlashDev.c
+++ b/source/nxp/iap_32kb/FlashDev.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"         // FlashOS Structures
+#include "FlashOS.h"         // FlashOS Structures
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!
 

--- a/source/nxp/iap_32kb/FlashPrg.c
+++ b/source/nxp/iap_32kb/FlashPrg.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 
 // Memory Mapping Control
 #define MEMMAP     (*((volatile unsigned long *) 0x40048000))

--- a/source/nxp/lpc4088_512kb_spifi/FlashDev.c
+++ b/source/nxp/lpc4088_512kb_spifi/FlashDev.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"         // FlashOS Structures
+#include "FlashOS.h"         // FlashOS Structures
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!
 

--- a/source/nxp/lpc4088_512kb_spifi/FlashPrg.c
+++ b/source/nxp/lpc4088_512kb_spifi/FlashPrg.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 
 // Memory Mapping Control
 #define MEMMAP   (*((volatile unsigned char *) 0x400FC040))

--- a/source/nxp/lpc54018/FlashDev.c
+++ b/source/nxp/lpc54018/FlashDev.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!
 

--- a/source/nxp/lpc54018/FlashPrg.c
+++ b/source/nxp/lpc54018/FlashPrg.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 #include "fsl_spifi.h"
 #include "string.h"
 

--- a/source/nxp/lpc54114/FlashDev.c
+++ b/source/nxp/lpc54114/FlashDev.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 #include "fsl_device_registers.h"
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!

--- a/source/nxp/lpc54114/FlashPrg.c
+++ b/source/nxp/lpc54114/FlashPrg.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 #include "fsl_flashiap.h"
 #include "fsl_power.h"
 #include "string.h"

--- a/source/nxp/lpc54608/FlashDev.c
+++ b/source/nxp/lpc54608/FlashDev.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 #include "fsl_device_registers.h"
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!

--- a/source/nxp/lpc54608/FlashPrg.c
+++ b/source/nxp/lpc54608/FlashPrg.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 #include "fsl_flashiap.h"
 #include "fsl_power.h"
 #include "string.h"

--- a/source/nxp/lpc8xx_32kb/FlashDev.c
+++ b/source/nxp/lpc8xx_32kb/FlashDev.c
@@ -24,7 +24,7 @@
  * Project:      Flash Device Description for NXP LPC8xx Flash using IAP
  * --------------------------------------------------------------------------- */
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!
 

--- a/source/nxp/lpc8xx_32kb/FlashPrg.c
+++ b/source/nxp/lpc8xx_32kb/FlashPrg.c
@@ -24,7 +24,7 @@
  * Project:      Flash Device Algorithm for NXP LPC8xx Flash using IAP
  * --------------------------------------------------------------------------- */
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 
 // Memory Mapping Control
 #define MEMMAP     (*((volatile unsigned char *) 0x40048000))

--- a/source/nxp/spifi/FlashDev.c
+++ b/source/nxp/spifi/FlashDev.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "../FlashOS.H"        // FlashOS Structures
+#include "../FlashOS.h"        // FlashOS Structures
 #include "FlashDev.h"
 
 struct FlashDevice const FlashDevice = {

--- a/source/nxp/spifi/FlashPrg.c
+++ b/source/nxp/spifi/FlashPrg.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "../FlashOS.H"        // FlashOS Structures
+#include "../FlashOS.h"        // FlashOS Structures
 #include "FlashDev.h"
 
 #include "spifi_rom_api.h"

--- a/source/onsemi/FlashDev.c
+++ b/source/onsemi/FlashDev.c
@@ -16,7 +16,7 @@
 
 /** @file FlashDev.c */
 
-#include "FlashOS.H"
+#include "FlashOS.h"
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!
 #define DEVICE_NAME    "NCS36510 640 KB Flash"

--- a/source/siliconlabs/EFM32GG/FlashDev.c
+++ b/source/siliconlabs/EFM32GG/FlashDev.c
@@ -16,7 +16,7 @@
 
 /** @file FlashDev.c */
 
-#include "FlashOS.H"
+#include "FlashOS.h"
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!
 #define DEVICE_NAME    "EFM32 Giant Gecko"

--- a/source/st/FlashDev.c
+++ b/source/st/FlashDev.c
@@ -29,7 +29,7 @@
  *    Initial release
  */ 
 
-#include "..\FlashOS.H"        // FlashOS Structures
+#include "..\FlashOS.h"        // FlashOS Structures
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!
 #define DEVICE_NAME    "STM32L151 256kB Flash"

--- a/source/st/FlashPrg.c
+++ b/source/st/FlashPrg.c
@@ -29,7 +29,7 @@
  *    Initial release
  */ 
 
-#include "..\FlashOS.H"        // FlashOS Structures
+#include "..\FlashOS.h"        // FlashOS Structures
 
 typedef volatile unsigned char  vu8;
 typedef volatile unsigned long  vu32;

--- a/source/st/STM32F4xx/FlashDev.c
+++ b/source/st/STM32F4xx/FlashDev.c
@@ -29,7 +29,7 @@
  *    Initial release
  */ 
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 
 #ifdef FLASH_MEM
 

--- a/source/st/STM32F4xx/FlashPrg.c
+++ b/source/st/STM32F4xx/FlashPrg.c
@@ -29,7 +29,7 @@
  *    Initial release
  */ 
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 
 typedef volatile unsigned char    vu8;
 typedef          unsigned char     u8;

--- a/source/st/STM32L0xx/FlashDev.c
+++ b/source/st/STM32L0xx/FlashDev.c
@@ -31,7 +31,7 @@
  *    Initial release
  */ 
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 
 #ifdef FLASH_MEMORY
 

--- a/source/st/STM32L0xx/FlashPrg.c
+++ b/source/st/STM32L0xx/FlashPrg.c
@@ -31,7 +31,7 @@
  *    Initial release
  */ 
 
-#include "FlashOS.H"        // FlashOS Structures
+#include "FlashOS.h"        // FlashOS Structures
 
 typedef volatile unsigned char  vu8;
 typedef volatile unsigned long  vu32;

--- a/source/template/FlashDev.c
+++ b/source/template/FlashDev.c
@@ -16,7 +16,7 @@
 
 /** @file FlashDev.c */
 
-#include "FlashOS.H"
+#include "FlashOS.h"
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!
 #define DEVICE_NAME    "XXXX"

--- a/source/ti/CC3220SF/FlashDev.c
+++ b/source/ti/CC3220SF/FlashDev.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
  /** @file FlashDev.c */
-#include "FlashOS.H"
+#include "FlashOS.h"
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!
 #define DEVICE_NAME    "CC3220SF"

--- a/source/toshiba/TZ10XX/FlashDev.c
+++ b/source/toshiba/TZ10XX/FlashDev.c
@@ -16,7 +16,7 @@
 
 /** @file FlashDev.c */
 
-#include "FlashOS.H"
+#include "FlashOS.h"
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!
 #define DEVICE_NAME    "TZ10XX on package NOR flash(1MB)"

--- a/source/wiznet/W7500/FlashDev.c
+++ b/source/wiznet/W7500/FlashDev.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"
+#include "FlashOS.h"
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!
 #define DEVICE_NAME    "W7500 128KB Flash"

--- a/source/wiznet/W7500/FlashPrg.c
+++ b/source/wiznet/W7500/FlashPrg.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "FlashOS.H"
+#include "FlashOS.h"
 
 #define IAP_ENTRY   0x1FFF1001
 


### PR DESCRIPTION
Building fails on linux because the file system is case-sensitive. #include FlashOS.H" does not result in "FlashOS.h" being included.     

```
Compiling ../../../source/wiznet/W7500/FlashDev.c
../../../source/wiznet/W7500/FlashDev.c:17:10: fatal error: FlashOS.H: No such file or directory
   17 | #include "FlashOS.H"
      |          ^~~~~~~~~~~
compilation terminated.
make: *** [Makefile:223：build/FlashDev.o] 错误 1
progen.tools.gccarm ERROR       Project: errors build failed with the status: projectfiles/make_gcc_arm/w7500/Makefile
```