### PR TITLE
add linux build github action for 'GCC with Make'

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -1,0 +1,25 @@
+name: linux develop build "GCC with Make"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: syphar/restore-virtualenv@v1
+    
+    - name: install requirements
+      run: sudo apt-get install -y gcc-arm-none-eabi
+      
+    - name: install requirements
+      run: pip install -r requirements.txt
+
+    - name: build
+      run: progen build -t make_gcc_arm


### PR DESCRIPTION
`progen build -t make_gcc_arm` returned a few compilation errors the first time I ran when reading `README.md`.  This pull request adds a github action to check whether the build is working.