### PR TITLE
Fix include path for stm32l151 project.

### DIFF
--- a/source/st/FlashDev.c
+++ b/source/st/FlashDev.c
@@ -29,7 +29,7 @@
  *    Initial release
  */ 
 
-#include "..\FlashOS.H"        // FlashOS Structures
+#include "FlashOS.H"        // FlashOS Structures
 
 #define FLASH_DRV_VERS (0x0100+VERS)   // Driver Version, do not modify!
 #define DEVICE_NAME    "STM32L151 256kB Flash"

--- a/source/st/FlashPrg.c
+++ b/source/st/FlashPrg.c
@@ -29,7 +29,7 @@
  *    Initial release
  */ 
 
-#include "..\FlashOS.H"        // FlashOS Structures
+#include "FlashOS.H"        // FlashOS Structures
 
 typedef volatile unsigned char  vu8;
 typedef volatile unsigned long  vu32;


### PR DESCRIPTION
A simple fix less intrusive that https://github.com/pyocd/FlashAlgo/pull/69, so separated into its own PR.

However, I have only tested that this builds with the `make_gcc_arm` progen tool option.