### PR TITLE
CI: Build each project independently on Linux and Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: linux develop build "GCC with Make"
+name: Build all projects with "GCC with Make"
 
 on:
   push:
@@ -10,6 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         project:
           - cc3220sf
           - efm32gg
@@ -61,8 +62,9 @@ jobs:
           # An empty string will build all projects, in case this list is outdated
           - ""
       fail-fast: false
-    runs-on: ubuntu-latest
-    name: Build ${{ matrix.project || 'all' }}
+    timeout-minutes: 10
+    runs-on: ${{ matrix.os }}
+    name: Build ${{ matrix.project || 'all' }} on ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - name: Setup Python
@@ -70,8 +72,10 @@ jobs:
       with:
         python-version: 3.8
         cache: pip
-    - name: install requirements
-      run: sudo apt-get install -y gcc-arm-none-eabi
+    - name: Setup arm-none-eabi-gcc
+      uses: carlosperate/arm-none-eabi-gcc-action@v1
+      with:
+        release: 10.3-2021.10
 
     - name: install requirements
       run: pip install -r requirements.txt

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -2,24 +2,79 @@ name: linux develop build "GCC with Make"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: '*'
   pull_request:
-    branches: [ "main" ]
+    branches: '*'
 
 jobs:
   build:
-
+    strategy:
+      matrix:
+        project:
+          - cc3220sf
+          - efm32gg
+          - lpc1114fn28
+          - lpc4088
+          - lpc54018
+          - lpc54114
+          - lpc54608
+          - lpc824
+          - mk20d5
+          - mk64f12
+          - mk65f18
+          - mk66f18
+          - mk80f25615
+          - mke15z7
+          - mke18f16
+          - mkl02z4
+          - mkl05z4
+          - mkl25z4
+          - mkl26z4
+          - mkl27z4
+          - mkl27z644
+          - mkl28z7
+          - mkl43z4
+          - mkl46z4
+          - mkv10z7
+          - mkv11z7
+          - mkv31f51212
+          - mkv58f22
+          - mkw01z4
+          - mkw30z4
+          - mkw40z4
+          - mkw41z4
+          - musca_a
+          - musca_b
+          - musca_b_eflash
+          - ncs36510
+          - nrf51xxx
+          - nrf52833
+          - stm32f4xx_2048
+          - stm32l0xx_192
+          - stm32l151
+          - stm32l475
+          - stm32wb55rc
+          - stm32wb55rg
+          - template
+          - tz10xx
+          - w7500
+          # An empty string will build all projects, in case this list is outdated
+          - ""
+      fail-fast: false
     runs-on: ubuntu-latest
-
+    name: Build ${{ matrix.project || 'all' }}
     steps:
     - uses: actions/checkout@v3
-    - uses: syphar/restore-virtualenv@v1
-    
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
+        cache: pip
     - name: install requirements
       run: sudo apt-get install -y gcc-arm-none-eabi
-      
+
     - name: install requirements
       run: pip install -r requirements.txt
 
     - name: build
-      run: progen build -t make_gcc_arm
+      run: progen build -t make_gcc_arm ${{ matrix.project}}


### PR DESCRIPTION
As some projects are failing to build, I thought it might be good addition to the CI to build all projects in a workflow matrix to be able to see the build state of each of one them independently.
One disadvantage of this approach is that if a new algo is added it needs to be added to the list in the CI yaml file as well, but I also added a job to build all, in case the list is not updated. 

Also added Windows runs, as sometimes something might work in one OS and fail in the other (fs case sensivitity, or path separators, usually being the most common causes). I didn't add macOS because that added another 48 jobs, and that might be too much.