### PR TITLE
requirements: add setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 project_generator==0.11.*
 Jinja2
 pyelftools
+setuptools


### PR DESCRIPTION
From a fresh installation of Ubuntu 24.04 with `build-essential`, there was an error when following the build instructions in the readme.

```
ModuleNotFoundError: No module named 'pkg_resources'
```

This was due to a missing `setuptools` package.

Add `setuptools` to `requirements.txt`.

Fixes #74